### PR TITLE
Add convenience function mapFrom.pick

### DIFF
--- a/src/map-from.ts
+++ b/src/map-from.ts
@@ -51,6 +51,25 @@ export const mapFrom = {
   },
 
   /**
+   * Maps the specified properties to themselves as is
+   *
+   * ```ts
+   * const objectMapperSchema = {
+   *   ...mapFrom.pick('a', 'b', 'c', 'd'),
+   * }
+   * ```
+   */
+  pick<TKey extends PropertyKey>(
+    key: TKey,
+    ...keys: TKey[]
+  ): { [K in TKey]: K } {
+    return [key, ...keys].reduce((acc, key) => {
+      acc[key] = key;
+      return acc;
+    }, {} as { [K in TKey]: K });
+  },
+
+  /**
    * Always map the output value to `undefined`
    *
    * ```ts

--- a/test/async-object-mapper.test.ts
+++ b/test/async-object-mapper.test.ts
@@ -4,6 +4,7 @@ import { expect } from "jsr:@std/expect";
 import { AsyncObjectMapper } from "../src/async-object-mapper.ts";
 import { OmitProperty } from "../src/omit-property.ts";
 import { mapFromAsync } from "../src/map-from-async.ts";
+import { mapFrom } from "../src/map-from.ts";
 
 function omit<TObject extends object, TKeys extends keyof TObject>(
   obj: TObject,
@@ -382,6 +383,88 @@ describe(AsyncObjectMapper.name, () => {
       out1: "FOO",
       out2: 123, // <-- DEFECT: unwanted property
       out3: 123,
+    });
+  });
+
+  it(`allows picking properties`, async () => {
+    interface Input {
+      firstName: string;
+      middleNames: string[];
+      lastName: string;
+      age: number;
+      taxFileNumber: string;
+    }
+
+    interface Output {
+      firstName: string;
+      lastName: string;
+      age: number;
+      fullName: string;
+    }
+
+    const objectMapper = AsyncObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick("firstName", "lastName", "age"),
+      fullName: async (input) => `${input.firstName} ${input.lastName}`,
+    });
+
+    expect(
+      await objectMapper.map({
+        firstName: "Shonky",
+        middleNames: ["The", "Artful"],
+        lastName: "Dodger",
+        age: 30,
+        taxFileNumber: "4",
+      }),
+    ).toStrictEqual({
+      firstName: "Shonky",
+      lastName: "Dodger",
+      age: 30,
+      fullName: "Shonky Dodger",
+    });
+
+    // @ts-expect-error: The schema includes `taxFileNumber`, which we don't want
+    AsyncObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick("firstName", "lastName", "age", "taxFileNumber"),
+      fullName: async (input) => `${input.firstName} ${input.lastName}`,
+    });
+
+    // @ts-expect-error: The schema includes `blockBusterMembershipNumber`, which doesn't exist in the input
+    AsyncObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick(
+        "firstName",
+        "lastName",
+        "age",
+        "blockBusterMembershipNumber",
+      ),
+      fullName: async (input) => `${input.firstName} ${input.lastName}`,
+    });
+  });
+
+  it(`prevents picking properties from input that don't match those in output type`, () => {
+    interface InputV1 {
+      foo: string;
+    }
+
+    interface OutputV1 {
+      foo: number;
+    }
+
+    // @ts-expect-error: The schema includes `foo`, which is incompatible with the output type
+    ObjectMapper.create<InputV1, OutputV1>()({
+      ...mapFrom.pick("foo"),
+    });
+
+    interface InputV2 {
+      foo?: string;
+    }
+
+    interface OutputV2 {
+      foo: string;
+    }
+
+    // @ts-expect-error: The schema includes `foo`, which is incompatible with the output type
+    ObjectMapper.create<InputV2, OutputV2>()({
+      ...mapFrom.pick("foo"),
     });
   });
 

--- a/test/object-mapper.test.ts
+++ b/test/object-mapper.test.ts
@@ -377,6 +377,91 @@ describe(ObjectMapper.name, () => {
     });
   });
 
+  it(`allows picking properties`, () => {
+    interface Input {
+      firstName: string;
+      middleNames: string[];
+      lastName: string;
+      age: number;
+      taxFileNumber: string;
+    }
+
+    interface Output {
+      firstName: string;
+      lastName: string;
+      age: number;
+      fullName: string;
+    }
+
+    const objectMapper = ObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick("firstName", "lastName", "age"),
+      fullName: (input) => `${input.firstName} ${input.lastName}`,
+    });
+
+    expect(objectMapper.map({
+      firstName: "Shonky",
+      middleNames: ["The", "Artful"],
+      lastName: "Dodger",
+      age: 30,
+      taxFileNumber: "4",
+    })).toStrictEqual({
+      firstName: "Shonky",
+      lastName: "Dodger",
+      age: 30,
+      fullName: "Shonky Dodger",
+    });
+
+    // @ts-expect-error: The schema includes `taxFileNumber`, which we don't want
+    ObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick("firstName", "lastName", "age", "taxFileNumber"),
+      fullName: (input) => `${input.firstName} ${input.lastName}`,
+    });
+
+    // @ts-expect-error: The schema includes `blockBusterMembershipNumber`, which doesn't exist in the input
+    ObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick(
+        "firstName",
+        "lastName",
+        "age",
+        "blockBusterMembershipNumber",
+      ),
+      fullName: (input) => `${input.firstName} ${input.lastName}`,
+    });
+
+    // @ts-expect-error: The schema excludes fullName, which is required in output
+    ObjectMapper.create<Input, Output>()({
+      ...mapFrom.pick("firstName", "lastName", "age"),
+    });
+  });
+
+  it(`prevents picking properties from input that don't match those in output type`, () => {
+    interface InputV1 {
+      foo: string;
+    }
+
+    interface OutputV1 {
+      foo: number;
+    }
+
+    // @ts-expect-error: The schema includes `foo`, which is incompatible with the output type
+    ObjectMapper.create<InputV1, OutputV1>()({
+      ...mapFrom.pick("foo"),
+    });
+
+    interface InputV2 {
+      foo?: string;
+    }
+
+    interface OutputV2 {
+      foo: string;
+    }
+
+    // @ts-expect-error: The schema includes `foo`, which is incompatible with the output type
+    ObjectMapper.create<InputV2, OutputV2>()({
+      ...mapFrom.pick("foo"),
+    });
+  });
+
   describe(`nested objects`, () => {
     interface Input {
       foo: string;


### PR DESCRIPTION
Adds a `pick` convenience method to the `mapFrom` utility, which returns a schema that simply picks the given property keys as is. This just DRYs up the mapping of many pass-through properties.

For example, this:

```ts
ObjectMapper.Create<Input, Output>({
  id: 'id',
  name: 'name',
  aliveAt: 'aliveAt',
  brightness: 'brightness',
  externalId: 'externalId',
  geoLocation: 'geoLocation',
  timezone: 'timezone',
  variant: 'variant',
  volume: 'volume',
  hardwareAccelerationEnabled: 'hardwareAccelerationEnabled',
  minimized: 'minimized',
  locked: 'locked',
  isTest: 'isTest',
  targetReleaseAfter: 'targetReleaseAfter',
  targetReleaseTimezone: 'targetReleaseTimezone',
  programmaticPackageType: 'programmaticPackageType',
  createdAt: 'createdAt',
  updatedAt: 'updatedAt',
  deletedAt: 'deletedAt',
  ...other mapping...
})
```

Would becomes this:

```ts
ObjectMapper.Create<Input, Output>({
  ...mapFrom.pick(
    'id',
    'name',
    'aliveAt',
    'brightness',
    'externalId',
    'geoLocation',
    'timezone',
    'variant',
    'volume',
    'hardwareAccelerationEnabled',
    'minimized',
    'locked',
    'isTest',
    'targetReleaseAfter',
    'targetReleaseTimezone',
    'programmaticPackageType',
    'createdAt',
    'updatedAt',
    'deletedAt'
  ),
  ...other mapping...
})
```

When I proposed this yesterday I believe you said the `mapFrom` utility was more designed for use with an individual property. I don't think that needs to be the case though, and I don't think it would be confusing if it wasn't, but that's just MHO. If you feel strongly about it, I can move it somewhere else.

Note I also had a short crack at picking nested paths (e.g. `'name', 'age', ['address', 'country']`) but wasn't able to get that working in the short time I had free today so left that for now but may revisit at a future date.

<details>
  <summary>Side note</summary>

  I actually think that some of the other methods on `mapFrom` could also *optionally* accept multiple keys in order to return a schema with those keys. For example:
  
  ```ts
  ObjectMapper.create<Input, Output>({
    ...mapFrom.omit('foo', 'bar'),
    ...mapFrom.pick('baz', 'qux', 'quux'),
    ...mapFrom.null('corge', 'grault'),
  })
  ```
  
  Would be the same as:
  
  ```ts
  ObjectMapper.create<Input, Output>({
    foo: mapFrom.omit(),
    bar: mapFrom.omit(),
    baz: 'baz',
    qux: 'qux',
    quux: 'quux',
    corge: mapFrom.null(),
    grault: mapFrom.null(),
  })
  ```
  
  Just a thought, which I don't want to distract from what this PR is trying to achieve.
</details>