### PR TITLE
Fix ESLint warning about unbound methods in `mapFrom`

### DIFF
--- a/src/map-from-async.ts
+++ b/src/map-from-async.ts
@@ -17,7 +17,7 @@ export const mapFromAsync = {
    * }
    * ```
    */
-  constant<TValue>(value: TValue): () => Promise<TValue> {
+  constant<TValue>(this: void, value: TValue): () => Promise<TValue> {
     return function constant(): Promise<TValue> {
       return Promise.resolve(value);
     };
@@ -33,7 +33,7 @@ export const mapFromAsync = {
    * }
    * ```
    */
-  omit(): Promise<OmitProperty> {
+  omit(this: void): Promise<OmitProperty> {
     return Promise.resolve(OmitProperty);
   },
 
@@ -46,7 +46,7 @@ export const mapFromAsync = {
    * }
    * ```
    */
-  null(): Promise<null> {
+  null(this: void): Promise<null> {
     return Promise.resolve(null);
   },
 
@@ -59,7 +59,7 @@ export const mapFromAsync = {
    * }
    * ```
    */
-  undefined(): Promise<undefined> {
+  undefined(this: void): Promise<undefined> {
     return Promise.resolve(undefined);
   },
 };

--- a/src/map-from.ts
+++ b/src/map-from.ts
@@ -17,7 +17,7 @@ export const mapFrom = {
    * }
    * ```
    */
-  constant<TValue>(value: TValue): () => TValue {
+  constant<TValue>(this: void, value: TValue): () => TValue {
     return function constant(): TValue {
       return value;
     };
@@ -33,7 +33,7 @@ export const mapFrom = {
    * }
    * ```
    */
-  omit(): OmitProperty {
+  omit(this: void): OmitProperty {
     return OmitProperty;
   },
 
@@ -46,7 +46,7 @@ export const mapFrom = {
    * }
    * ```
    */
-  null(): null {
+  null(this: void): null {
     return null;
   },
 
@@ -60,6 +60,7 @@ export const mapFrom = {
    * ```
    */
   pick<TKey extends PropertyKey>(
+    this: void,
     key: TKey,
     ...keys: TKey[]
   ): { [K in TKey]: K } {
@@ -78,7 +79,7 @@ export const mapFrom = {
    * }
    * ```
    */
-  undefined(): undefined {
+  undefined(this: void): undefined {
     return undefined;
   },
 };


### PR DESCRIPTION
Fix ESLint warning about unbound methods in `mapFrom` convenience functions, by explicitly specifying `this` as `void`.

Fixes #3 